### PR TITLE
Add weather alerts hub and saved drive management screens

### DIFF
--- a/client/app/(tabs)/alert-details.tsx
+++ b/client/app/(tabs)/alert-details.tsx
@@ -1,0 +1,359 @@
+import React, { JSX, useMemo } from 'react';
+import {
+  Alert,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import moment from 'moment';
+import { Colors } from '@/constants/Colors';
+import { getSeverityBaseColor, getSeverityColor, getSeverityLabel } from '@/scripts/alerts';
+import { WeatherAlert } from '@/types/weather';
+
+const weatherAlertData = require('../../assets/data/all_weather_alerts.json');
+
+type Timeframe = 'active' | 'upcoming' | 'expired';
+
+type InfoRowProps = {
+  label: string;
+  value: string;
+};
+
+const classifyTimeframe = (alert: WeatherAlert): Timeframe => {
+  const now = moment();
+  const start = moment(alert.start);
+  const end = moment(alert.end);
+
+  if (start.isValid() && now.isBefore(start)) {
+    return 'upcoming';
+  }
+
+  if (end.isValid() && now.isAfter(end)) {
+    return 'expired';
+  }
+
+  return 'active';
+};
+
+const formatTimestamp = (value: string, withRelative: boolean = false): string => {
+  const timestamp = moment(value);
+
+  if (!timestamp.isValid()) {
+    return 'Unavailable';
+  }
+
+  if (withRelative) {
+    return `${timestamp.format('MMM D, YYYY h:mm A')} • ${timestamp.fromNow()}`;
+  }
+
+  return timestamp.format('MMM D, YYYY h:mm A');
+};
+
+const alertList = (weatherAlertData.alerts ?? []) as WeatherAlert[];
+
+const InfoRow = ({ label, value }: InfoRowProps): JSX.Element => (
+  <View style={styles.infoRow}>
+    <Text style={styles.infoLabel}>{label}</Text>
+    <Text style={styles.infoValue}>{value}</Text>
+  </View>
+);
+
+const AlertDetailsScreen = (): JSX.Element => {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ id?: string }>();
+
+  const selectedAlert = useMemo(() => {
+    if (!params?.id) {
+      return undefined;
+    }
+
+    return alertList.find((alert) => alert.id === params.id);
+  }, [params?.id]);
+
+  if (!selectedAlert) {
+    return (
+      <View style={styles.emptyContainer}>
+        <StatusBar style="dark" />
+        <Ionicons name="alert-circle-outline" size={48} color={Colors.soft} />
+        <Text style={styles.emptyTitle}>We couldn't find that alert</Text>
+        <Text style={styles.emptySubtitle}>
+          The alert you're looking for may have expired or been removed from the feed.
+        </Text>
+        <TouchableOpacity style={styles.primaryButton} onPress={() => router.back()}>
+          <Text style={styles.primaryButtonText}>Go back</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  const severityLabel = getSeverityLabel(selectedAlert.severity);
+  const severityColor = getSeverityBaseColor(severityLabel);
+  const timeframe = classifyTimeframe(selectedAlert);
+
+  const timeframeLabel: Record<Timeframe, string> = {
+    active: 'Active now',
+    upcoming: 'Starts soon',
+    expired: 'Expired',
+  };
+
+  const openExternalLink = async () => {
+    if (!selectedAlert.link) {
+      return;
+    }
+
+    try {
+      await Linking.openURL(selectedAlert.link);
+    } catch (error) {
+      Alert.alert('Unable to open link', 'Please try again later.');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar style="dark" />
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.iconButton} onPress={() => router.back()}>
+          <Ionicons name="arrow-back" size={22} color={Colors.bold} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Alert details</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.overviewCard}>
+          <Text style={styles.alertTitle}>{selectedAlert.title}</Text>
+          {selectedAlert.event?.length ? (
+            <Text style={styles.alertEvent}>{selectedAlert.event}</Text>
+          ) : null}
+
+          <View style={styles.pillRow}>
+            <View
+              style={[
+                styles.severityPill,
+                {
+                  backgroundColor: getSeverityColor(severityLabel, 0.15),
+                  borderColor: severityColor,
+                },
+              ]}
+            >
+              <Text style={[styles.severityText, { color: severityColor }]}>{severityLabel}</Text>
+            </View>
+            <View style={styles.timeframePill}>
+              <Ionicons name="time-outline" size={16} color={Colors.regular} />
+              <Text style={styles.timeframeText}>{timeframeLabel[timeframe]}</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Timeline</Text>
+          <InfoRow label="Effective" value={formatTimestamp(selectedAlert.start, true)} />
+          <InfoRow label="Expires" value={formatTimestamp(selectedAlert.end, true)} />
+          <InfoRow label="Last updated" value={formatTimestamp(selectedAlert.updated, true)} />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Impact overview</Text>
+          <InfoRow label="Impacted zones" value={`${selectedAlert.geometry?.length ?? 0}`} />
+          <InfoRow label="Minimum latitude" value={selectedAlert.min_lat?.toFixed(2) ?? '—'} />
+          <InfoRow label="Maximum latitude" value={selectedAlert.max_lat?.toFixed(2) ?? '—'} />
+          <InfoRow label="Minimum longitude" value={selectedAlert.min_lon?.toFixed(2) ?? '—'} />
+          <InfoRow label="Maximum longitude" value={selectedAlert.max_lon?.toFixed(2) ?? '—'} />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Summary</Text>
+          <Text style={styles.sectionBody}>
+            {selectedAlert.message?.length ? selectedAlert.message : 'No summary available for this alert.'}
+          </Text>
+        </View>
+
+        {selectedAlert.link?.length ? (
+          <TouchableOpacity style={styles.primaryButton} onPress={openExternalLink}>
+            <Ionicons name="open-outline" size={18} color={Colors.background} style={styles.primaryButtonIcon} />
+            <Text style={styles.primaryButtonText}>View official bulletin</Text>
+          </TouchableOpacity>
+        ) : null}
+      </ScrollView>
+    </View>
+  );
+};
+
+export default AlertDetailsScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 12,
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: Colors.input,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#00000010',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  headerSpacer: {
+    width: 36,
+    height: 36,
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+  },
+  overviewCard: {
+    backgroundColor: Colors.input,
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 20,
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  alertTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: Colors.bold,
+    marginBottom: 8,
+  },
+  alertEvent: {
+    fontSize: 15,
+    color: Colors.regular,
+    marginBottom: 16,
+  },
+  pillRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  severityPill: {
+    borderRadius: 16,
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+    borderWidth: 1,
+    marginRight: 10,
+  },
+  severityText: {
+    fontSize: 13,
+    fontWeight: 'bold',
+  },
+  timeframePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.secondary,
+    borderRadius: 16,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+  },
+  timeframeText: {
+    marginLeft: 6,
+    fontSize: 13,
+    color: Colors.regular,
+    fontWeight: '600',
+  },
+  section: {
+    backgroundColor: Colors.input,
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 20,
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 1,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Colors.bold,
+    marginBottom: 12,
+  },
+  sectionBody: {
+    fontSize: 14,
+    color: Colors.regular,
+    lineHeight: 20,
+  },
+  infoRow: {
+    marginBottom: 10,
+  },
+  infoLabel: {
+    fontSize: 12,
+    color: Colors.soft,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  infoValue: {
+    marginTop: 2,
+    fontSize: 15,
+    color: Colors.bold,
+  },
+  primaryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.primary,
+    borderRadius: 14,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    marginTop: 10,
+    shadowColor: '#00000014',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  primaryButtonIcon: {
+    marginRight: 8,
+  },
+  primaryButtonText: {
+    color: Colors.background,
+    fontWeight: 'bold',
+    fontSize: 15,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.background,
+    padding: 24,
+  },
+  emptyTitle: {
+    marginTop: 16,
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: Colors.bold,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    marginTop: 8,
+    fontSize: 14,
+    color: Colors.regular,
+    textAlign: 'center',
+  },
+});

--- a/client/app/(tabs)/profile.tsx
+++ b/client/app/(tabs)/profile.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, JSX } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, Alert } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Ionicons, FontAwesome5 } from '@expo/vector-icons';
+import { Ionicons, FontAwesome5, MaterialCommunityIcons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as ImagePicker from 'expo-image-picker';
 import { useFocusEffect } from '@react-navigation/native';
@@ -138,6 +138,16 @@ export default function ProfileScreen(): JSX.Element {
           title="Plan a drive"
           icon={<Ionicons name="car-outline" size={20} color={Colors.bold} />}
           onPress={() => router.navigate('/(tabs)/map')}
+        />
+        <ProfileOption
+          title="Saved drives"
+          icon={<MaterialCommunityIcons name="bookmark-outline" size={20} color={Colors.bold} />}
+          onPress={() => router.navigate('/(tabs)/saved-drives')}
+        />
+        <ProfileOption
+          title="Weather alerts"
+          icon={<Ionicons name="warning-outline" size={20} color={Colors.bold} />}
+          onPress={() => router.navigate('/(tabs)/weather-alerts')}
         />
         <ProfileOption
           title="Settings"

--- a/client/app/(tabs)/saved-drives.tsx
+++ b/client/app/(tabs)/saved-drives.tsx
@@ -1,0 +1,478 @@
+import React, { JSX, useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFocusEffect } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import moment from 'moment';
+import { Colors } from '@/constants/Colors';
+import { STORAGE_KEYS } from '@/constants/storage';
+import { SavedRoute } from '@/types/routes';
+import { AlertSummary } from '@/types/weather';
+import { getSeverityBaseColor, getSeverityColor, getSeverityLabel } from '@/scripts/alerts';
+
+const SavedDrivesScreen = (): JSX.Element => {
+  const router = useRouter();
+  const [savedRoute, setSavedRoute] = useState<SavedRoute | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const loadSavedRoute = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const storedRoute = await AsyncStorage.getItem(STORAGE_KEYS.savedRoute);
+
+      if (storedRoute) {
+        const parsedRoute: SavedRoute = JSON.parse(storedRoute);
+
+        if (parsedRoute && Array.isArray(parsedRoute.coordinates)) {
+          setSavedRoute(parsedRoute);
+        } else {
+          setSavedRoute(null);
+        }
+      } else {
+        setSavedRoute(null);
+      }
+    } catch (error) {
+      console.error('Error loading saved route', error);
+      setSavedRoute(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadSavedRoute();
+    }, [loadSavedRoute])
+  );
+
+  const handleNavigateToMap = () => {
+    router.push('/(tabs)/map');
+  };
+
+  const confirmRemoval = () => {
+    Alert.alert(
+      'Remove saved drive',
+      'Removing this drive will delete your saved waypoints and alert information.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: async () => {
+            await AsyncStorage.removeItem(STORAGE_KEYS.savedRoute);
+            await AsyncStorage.removeItem(STORAGE_KEYS.legacyRoute);
+            setSavedRoute(null);
+          },
+        },
+      ]
+    );
+  };
+
+  const renderAlertSummary = (summary: AlertSummary) => {
+    const severityLabel = getSeverityLabel(summary.severity);
+    const severityColor = getSeverityBaseColor(severityLabel);
+
+    return (
+      <View key={summary.id} style={styles.alertCard}>
+        <View
+          style={[
+            styles.alertSeverityPill,
+            {
+              backgroundColor: getSeverityColor(severityLabel, 0.15),
+              borderColor: severityColor,
+            },
+          ]}
+        >
+          <Text style={[styles.alertSeverityText, { color: severityColor }]}>{severityLabel}</Text>
+        </View>
+        <Text style={styles.alertTitle} numberOfLines={2}>
+          {summary.title}
+        </Text>
+        {summary.event?.length ? (
+          <Text style={styles.alertEvent} numberOfLines={1}>
+            {summary.event}
+          </Text>
+        ) : null}
+        {summary.expires?.length ? (
+          <Text style={styles.alertExpires}>Expires {moment(summary.expires).fromNow()}</Text>
+        ) : null}
+      </View>
+    );
+  };
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="small" color={Colors.primary} />
+          <Text style={styles.loadingText}>Loading saved drives...</Text>
+        </View>
+      );
+    }
+
+    if (!savedRoute) {
+      return (
+        <View style={styles.emptyState}>
+          <Ionicons name="bookmark-outline" size={48} color={Colors.soft} />
+          <Text style={styles.emptyTitle}>No drives saved yet</Text>
+          <Text style={styles.emptySubtitle}>
+            Plan your route and tap the bookmark icon on the map to save it here for quick access.
+          </Text>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleNavigateToMap}>
+            <Text style={styles.primaryButtonText}>Plan a drive</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    return (
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryLabel}>Saved on</Text>
+          <Text style={styles.summaryValue}>
+            {moment(savedRoute.savedAt).format('MMM D, YYYY h:mm A')} ({moment(savedRoute.savedAt).fromNow()})
+          </Text>
+
+          <View style={styles.routeRow}>
+            <Ionicons name="flag-outline" size={18} color={Colors.regular} />
+            <Text style={styles.routeText}>{savedRoute.originLabel}</Text>
+          </View>
+          <View style={styles.routeConnector}>
+            <View style={styles.routeLine} />
+            <Ionicons name="navigate-outline" size={16} color={Colors.secondary} />
+            <View style={styles.routeLine} />
+          </View>
+          <View style={styles.routeRow}>
+            <Ionicons name="flag" size={18} color={Colors.regular} />
+            <Text style={styles.routeText}>{savedRoute.destinationLabel}</Text>
+          </View>
+
+          <View style={styles.metaRow}>
+            <View style={styles.metaItem}>
+              <Ionicons name="time-outline" size={16} color={Colors.regular} />
+              <Text style={styles.metaLabel}>Drive time</Text>
+              <Text style={styles.metaValue}>{savedRoute.durationText || '—'}</Text>
+            </View>
+            <View style={styles.metaItem}>
+              <Ionicons name="speedometer-outline" size={16} color={Colors.regular} />
+              <Text style={styles.metaLabel}>Distance</Text>
+              <Text style={styles.metaValue}>{savedRoute.distanceText || '—'}</Text>
+            </View>
+            <View style={styles.metaItem}>
+              <Ionicons name="calendar-outline" size={16} color={Colors.regular} />
+              <Text style={styles.metaLabel}>Arrival</Text>
+              <Text style={styles.metaValue}>{savedRoute.arrivalTime || '—'}</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Weather alerts on this route</Text>
+            {savedRoute.alertSummaries.length > 0 ? (
+              <Text style={styles.sectionBadge}>{savedRoute.alertSummaries.length}</Text>
+            ) : null}
+          </View>
+          {savedRoute.alertSummaries.length > 0 ? (
+            savedRoute.alertSummaries.map(renderAlertSummary)
+          ) : (
+            <Text style={styles.sectionSubtitle}>No weather alerts saved with this drive.</Text>
+          )}
+        </View>
+
+        <View style={styles.buttonRow}>
+          <TouchableOpacity style={styles.secondaryButton} onPress={confirmRemoval}>
+            <Ionicons name="trash-outline" size={18} color={Colors.error} style={styles.secondaryIcon} />
+            <Text style={[styles.secondaryButtonText, { color: Colors.error }]}>Remove</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleNavigateToMap}>
+            <Ionicons name="navigate" size={18} color={Colors.background} style={styles.primaryButtonIcon} />
+            <Text style={styles.primaryButtonText}>Open in map</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar style="dark" />
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.iconButton} onPress={() => router.back()}>
+          <Ionicons name="arrow-back" size={22} color={Colors.bold} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Saved drives</Text>
+        <TouchableOpacity style={styles.iconButton} onPress={handleNavigateToMap}>
+          <Ionicons name="map-outline" size={22} color={Colors.bold} />
+        </TouchableOpacity>
+      </View>
+      {renderContent()}
+    </View>
+  );
+};
+
+export default SavedDrivesScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 12,
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: Colors.input,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#00000010',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+  },
+  summaryCard: {
+    backgroundColor: Colors.input,
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 20,
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  summaryLabel: {
+    fontSize: 12,
+    color: Colors.soft,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  summaryValue: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Colors.bold,
+    marginBottom: 16,
+  },
+  routeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  routeText: {
+    marginLeft: 8,
+    fontSize: 15,
+    color: Colors.regular,
+    flexShrink: 1,
+  },
+  routeConnector: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 4,
+  },
+  routeLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: Colors.secondary,
+    marginHorizontal: 4,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 16,
+  },
+  metaItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  metaLabel: {
+    marginTop: 6,
+    fontSize: 12,
+    color: Colors.soft,
+    textTransform: 'uppercase',
+  },
+  metaValue: {
+    marginTop: 4,
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  section: {
+    backgroundColor: Colors.input,
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 20,
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 1,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  sectionBadge: {
+    minWidth: 28,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
+    backgroundColor: Colors.secondary,
+    color: Colors.regular,
+    textAlign: 'center',
+    fontWeight: 'bold',
+    fontSize: 12,
+  },
+  sectionSubtitle: {
+    fontSize: 14,
+    color: Colors.regular,
+  },
+  alertCard: {
+    backgroundColor: Colors.background,
+    borderRadius: 14,
+    padding: 14,
+    marginBottom: 12,
+  },
+  alertSeverityPill: {
+    alignSelf: 'flex-start',
+    borderRadius: 12,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderWidth: 1,
+    marginBottom: 8,
+  },
+  alertSeverityText: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  alertTitle: {
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  alertEvent: {
+    marginTop: 4,
+    fontSize: 13,
+    color: Colors.regular,
+  },
+  alertExpires: {
+    marginTop: 8,
+    fontSize: 12,
+    color: Colors.soft,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  secondaryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: Colors.input,
+    flex: 1,
+    marginRight: 12,
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 1,
+  },
+  secondaryIcon: {
+    marginRight: 8,
+  },
+  secondaryButtonText: {
+    fontSize: 15,
+    fontWeight: 'bold',
+  },
+  primaryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.primary,
+    borderRadius: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    flex: 1,
+    shadowColor: '#00000014',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  primaryButtonIcon: {
+    marginRight: 8,
+  },
+  primaryButtonText: {
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: Colors.background,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    marginTop: 16,
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: Colors.bold,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    marginTop: 8,
+    fontSize: 14,
+    color: Colors.regular,
+    textAlign: 'center',
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: Colors.regular,
+  },
+});

--- a/client/app/(tabs)/weather-alerts.tsx
+++ b/client/app/(tabs)/weather-alerts.tsx
@@ -1,0 +1,519 @@
+import React, { JSX, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  ListRenderItem,
+} from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import moment from 'moment';
+import { Colors } from '@/constants/Colors';
+import { getSeverityBaseColor, getSeverityColor, getSeverityLabel } from '@/scripts/alerts';
+import { WeatherAlert } from '@/types/weather';
+
+const weatherAlertData = require('../../assets/data/all_weather_alerts.json');
+
+const severityFilters = ['All', 'Minor', 'Moderate', 'Severe'];
+
+const timeframeFilters = [
+  { label: 'Active', value: 'active' as const },
+  { label: 'Upcoming', value: 'upcoming' as const },
+  { label: 'Expired', value: 'expired' as const },
+  { label: 'All', value: 'all' as const },
+];
+
+type TimeframeValue = 'active' | 'upcoming' | 'expired' | 'all';
+
+type AlertWithTimeframe = WeatherAlert & { timeframe: Exclude<TimeframeValue, 'all'> };
+
+const classifyTimeframe = (alert: WeatherAlert): AlertWithTimeframe['timeframe'] => {
+  const now = moment();
+  const start = moment(alert.start);
+  const end = moment(alert.end);
+
+  if (start.isValid() && now.isBefore(start)) {
+    return 'upcoming';
+  }
+
+  if (end.isValid() && now.isAfter(end)) {
+    return 'expired';
+  }
+
+  return 'active';
+};
+
+const formatTimeRange = (alert: WeatherAlert): string => {
+  const start = moment(alert.start);
+  const end = moment(alert.end);
+
+  if (start.isValid() && end.isValid()) {
+    return `${start.format('MMM D, h:mm A')} - ${end.format('MMM D, h:mm A')}`;
+  }
+
+  if (start.isValid()) {
+    return `Starts ${start.fromNow()}`;
+  }
+
+  if (end.isValid()) {
+    return `Ends ${end.fromNow()}`;
+  }
+
+  return 'Timing unavailable';
+};
+
+const getAlertList = (): WeatherAlert[] => {
+  return (weatherAlertData.alerts ?? []) as WeatherAlert[];
+};
+
+const WeatherAlertsScreen = (): JSX.Element => {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedSeverity, setSelectedSeverity] = useState<string>('All');
+  const [selectedTimeframe, setSelectedTimeframe] = useState<TimeframeValue>('active');
+
+  const allAlerts = useMemo(() => getAlertList(), []);
+
+  const alertsWithTimeframe = useMemo<AlertWithTimeframe[]>(() => {
+    return allAlerts.map((alert) => ({
+      ...alert,
+      timeframe: classifyTimeframe(alert),
+    }));
+  }, [allAlerts]);
+
+  const timeframeSummary = useMemo(() => {
+    return alertsWithTimeframe.reduce<Record<'active' | 'upcoming' | 'expired', number>>(
+      (acc, alert) => {
+        acc[alert.timeframe] += 1;
+        return acc;
+      },
+      { active: 0, upcoming: 0, expired: 0 }
+    );
+  }, [alertsWithTimeframe]);
+
+  const filteredAlerts = useMemo<AlertWithTimeframe[]>(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+
+    return alertsWithTimeframe.filter((alert) => {
+      const severityLabel = getSeverityLabel(alert.severity);
+      const matchesSeverity =
+        selectedSeverity === 'All' || severityLabel === selectedSeverity;
+
+      const matchesTimeframe =
+        selectedTimeframe === 'all' || alert.timeframe === selectedTimeframe;
+
+      const matchesSearch = normalizedQuery.length === 0
+        ? true
+        : [alert.title, alert.message, alert.event]
+            .filter(Boolean)
+            .some((value) => value.toLowerCase().includes(normalizedQuery));
+
+      return matchesSeverity && matchesTimeframe && matchesSearch;
+    });
+  }, [alertsWithTimeframe, searchQuery, selectedSeverity, selectedTimeframe]);
+
+  const renderAlertCard: ListRenderItem<AlertWithTimeframe> = ({ item }) => {
+    const severityLabel = getSeverityLabel(item.severity);
+    const severityColor = getSeverityBaseColor(severityLabel);
+
+    return (
+      <TouchableOpacity
+        style={styles.alertCard}
+        activeOpacity={0.85}
+        onPress={() =>
+          router.push({
+            pathname: '/(tabs)/alert-details',
+            params: { id: item.id },
+          })
+        }
+      >
+        <View style={styles.cardHeader}>
+          <Text style={styles.cardTitle} numberOfLines={2}>
+            {item.title}
+          </Text>
+          <View
+            style={[
+              styles.severityPill,
+              {
+                backgroundColor: getSeverityColor(severityLabel, 0.15),
+                borderColor: severityColor,
+              },
+            ]}
+          >
+            <Text style={[styles.severityText, { color: severityColor }]}>
+              {severityLabel}
+            </Text>
+          </View>
+        </View>
+        {item.event?.length ? (
+          <Text style={styles.cardEvent} numberOfLines={1}>
+            {item.event}
+          </Text>
+        ) : null}
+        {item.message?.length ? (
+          <Text style={styles.cardMessage} numberOfLines={3}>
+            {item.message}
+          </Text>
+        ) : null}
+        <View style={styles.cardFooter}>
+          <View style={styles.metaRow}>
+            <Ionicons name="time-outline" size={16} color={Colors.regular} />
+            <Text style={styles.metaText}>{formatTimeRange(item)}</Text>
+          </View>
+          <View style={styles.metaRow}>
+            <Ionicons name="navigate-outline" size={16} color={Colors.regular} />
+            <Text style={styles.metaText}>{item.timeframe.toUpperCase()}</Text>
+          </View>
+        </View>
+        <View style={styles.cardLinkRow}>
+          <Text style={styles.cardLinkText}>View details</Text>
+          <Ionicons
+            name="chevron-forward"
+            size={16}
+            color={Colors.regular}
+            style={styles.cardLinkIcon}
+          />
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderSeverityChip = (option: string): JSX.Element => {
+    const isSelected = option === selectedSeverity;
+    const baseColor =
+      option === 'All' ? Colors.regular : getSeverityBaseColor(option);
+
+    return (
+      <TouchableOpacity
+        key={option}
+        style={[
+          styles.filterChip,
+          isSelected && {
+            backgroundColor:
+              option === 'All'
+                ? Colors.secondary
+                : getSeverityColor(option, 0.15),
+            borderColor: baseColor,
+          },
+        ]}
+        onPress={() => setSelectedSeverity(option)}
+      >
+        <Text
+          style={[
+            styles.filterChipText,
+            isSelected && { color: baseColor },
+          ]}
+        >
+          {option}
+        </Text>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderTimeframeChip = (label: string, value: TimeframeValue): JSX.Element => {
+    const isSelected = value === selectedTimeframe;
+
+    return (
+      <TouchableOpacity
+        key={value}
+        style={[
+          styles.filterChip,
+          isSelected && {
+            backgroundColor: Colors.secondary,
+            borderColor: Colors.regular,
+          },
+        ]}
+        onPress={() => setSelectedTimeframe(value)}
+      >
+        <Text
+          style={[
+            styles.filterChipText,
+            isSelected && { color: Colors.regular },
+          ]}
+        >
+          {label}
+        </Text>
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar style="dark" />
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.iconButton}
+          onPress={() => router.back()}
+        >
+          <Ionicons name="arrow-back" size={22} color={Colors.bold} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Weather alerts</Text>
+        <TouchableOpacity
+          style={styles.iconButton}
+          onPress={() => router.push('/(tabs)/map')}
+        >
+          <Ionicons name="map-outline" size={22} color={Colors.bold} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.summaryRow}>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryValue}>{timeframeSummary.active}</Text>
+          <Text style={styles.summaryLabel}>Active</Text>
+        </View>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryValue}>{timeframeSummary.upcoming}</Text>
+          <Text style={styles.summaryLabel}>Upcoming</Text>
+        </View>
+        <View style={styles.summaryCard}>
+          <Text style={styles.summaryValue}>{timeframeSummary.expired}</Text>
+          <Text style={styles.summaryLabel}>Expired</Text>
+        </View>
+      </View>
+
+      <View style={styles.searchContainer}>
+        <Ionicons name="search" size={18} color={Colors.regular} />
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search alerts"
+          placeholderTextColor={Colors.soft}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          returnKeyType="search"
+        />
+      </View>
+
+      <Text style={styles.filterLabel}>Severity</Text>
+      <View style={styles.filterRow}>
+        {severityFilters.map(renderSeverityChip)}
+      </View>
+
+      <Text style={styles.filterLabel}>Timeline</Text>
+      <View style={styles.filterRow}>
+        {timeframeFilters.map(({ label, value }) => renderTimeframeChip(label, value))}
+      </View>
+
+      <FlatList
+        data={filteredAlerts}
+        renderItem={renderAlertCard}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Ionicons name="sunny-outline" size={42} color={Colors.soft} />
+            <Text style={styles.emptyTitle}>No alerts match your filters</Text>
+            <Text style={styles.emptySubtitle}>
+              Try adjusting the severity or timeframe to explore a different set of
+              weather advisories.
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+};
+
+export default WeatherAlertsScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    padding: 20,
+    paddingBottom: 0,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: Colors.input,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#00000010',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  summaryCard: {
+    flex: 1,
+    backgroundColor: Colors.input,
+    borderRadius: 14,
+    paddingVertical: 14,
+    paddingHorizontal: 12,
+    marginHorizontal: 4,
+    alignItems: 'center',
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  summaryValue: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  summaryLabel: {
+    marginTop: 4,
+    color: Colors.regular,
+    fontSize: 13,
+  },
+  searchContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.input,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 1,
+    marginBottom: 16,
+  },
+  searchInput: {
+    flex: 1,
+    marginLeft: 8,
+    fontSize: 15,
+    color: Colors.bold,
+  },
+  filterLabel: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: Colors.regular,
+    marginBottom: 8,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 16,
+  },
+  filterChip: {
+    borderRadius: 20,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    backgroundColor: '#ffffff80',
+    borderWidth: 1,
+    borderColor: '#ffffff',
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  filterChipText: {
+    fontSize: 13,
+    color: Colors.soft,
+  },
+  listContent: {
+    paddingBottom: 120,
+  },
+  alertCard: {
+    backgroundColor: Colors.input,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#0000000d',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.08,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  cardTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Colors.bold,
+    marginRight: 12,
+  },
+  severityPill: {
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  severityText: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  cardEvent: {
+    fontSize: 14,
+    color: Colors.regular,
+    marginBottom: 4,
+  },
+  cardMessage: {
+    fontSize: 13,
+    color: Colors.regular,
+    marginBottom: 12,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  metaText: {
+    fontSize: 12,
+    color: Colors.soft,
+    marginLeft: 6,
+  },
+  cardLinkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  cardLinkText: {
+    fontSize: 13,
+    color: Colors.regular,
+    fontWeight: 'bold',
+  },
+  cardLinkIcon: {
+    marginLeft: 4,
+  },
+  emptyState: {
+    alignItems: 'center',
+    marginTop: 60,
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    marginTop: 16,
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: Colors.bold,
+  },
+  emptySubtitle: {
+    marginTop: 8,
+    fontSize: 14,
+    textAlign: 'center',
+    color: Colors.regular,
+  },
+});

--- a/client/constants/storage.ts
+++ b/client/constants/storage.ts
@@ -1,0 +1,4 @@
+export const STORAGE_KEYS = {
+  savedRoute: 'savedRoute',
+  legacyRoute: 'route',
+} as const;

--- a/client/scripts/alerts.ts
+++ b/client/scripts/alerts.ts
@@ -1,0 +1,26 @@
+import { Colors } from '@/constants/Colors';
+import hexToRgba from '@/scripts/color';
+
+const severityPalette: Record<string, string> = {
+  Minor: Colors.alertMinor,
+  Moderate: Colors.alertModerate,
+  Severe: Colors.alertSevere,
+};
+
+export const getSeverityBaseColor = (severity: string): string => {
+  return severityPalette[severity] ?? Colors.alertUnknown;
+};
+
+export const getSeverityColor = (severity: string, opacity: number = 1): string => {
+  const baseColor = getSeverityBaseColor(severity);
+
+  if (opacity >= 1) {
+    return baseColor;
+  }
+
+  return hexToRgba(baseColor, opacity);
+};
+
+export const getSeverityLabel = (severity: string): string => {
+  return severity && severity.trim().length > 0 ? severity : 'Unknown';
+};

--- a/client/types/routes.ts
+++ b/client/types/routes.ts
@@ -1,0 +1,14 @@
+import { LatLng } from 'react-native-maps';
+import { AlertSummary } from './weather';
+
+export interface SavedRoute {
+  id: string;
+  savedAt: string;
+  originLabel: string;
+  destinationLabel: string;
+  distanceText: string;
+  durationText: string;
+  arrivalTime?: string;
+  coordinates: LatLng[];
+  alertSummaries: AlertSummary[];
+}

--- a/client/types/weather.ts
+++ b/client/types/weather.ts
@@ -1,0 +1,29 @@
+export interface Geometry {
+  type: string;
+  coordinates: number[][][];
+}
+
+export interface WeatherAlert {
+  id: string;
+  start: string;
+  end: string;
+  updated: string;
+  severity: string;
+  event: string;
+  title: string;
+  message: string;
+  link: string;
+  geometry: Geometry[];
+  min_lat: number;
+  max_lat: number;
+  min_lon: number;
+  max_lon: number;
+}
+
+export interface AlertSummary {
+  id: string;
+  title: string;
+  severity: string;
+  event?: string;
+  expires?: string;
+}


### PR DESCRIPTION
## Summary
- implement a weather alerts browser with severity/time filters and navigation into detailed alerts
- add detailed alert and saved drive management screens backed by AsyncStorage data
- enhance map persistence, share storage/severity utilities, and expose the new features through the profile menu

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*
- npx tsc --noEmit *(fails: existing type/style issues in legacy auth screens and shared components)*

------
https://chatgpt.com/codex/tasks/task_e_68d12fd55f20832683701eceaa90bca5